### PR TITLE
Corrected 2 typos: **where** was changed to **were** in analytics

### DIFF
--- a/analytics/analytics.md
+++ b/analytics/analytics.md
@@ -4,7 +4,7 @@
 
 Analytics is part of almost all enterprise applications and it comes down to the company wanting to know various things about the users using the application.
 
-The information that is desired can vary but the basics are what device was used, what pages where visited, what buttons where clicked and how long the user stayed before leaving.
+The information that is desired can vary but the basics are what device was used, what pages were visited, what buttons were clicked and how long the user stayed before leaving.
 
 ## Common tools
 


### PR DESCRIPTION
Hey Fredrik!

Thanks for your selfless guide on YouTube. Especially this new one on what journey to take in 2019 to become a better/pro Javascript Fullstack Engineer.

While reading the Analytics section, I found two typos...you wanted to use **were**, the plural state of **was** but you used **where**. This happened in two places in a statement.

So, I thought I could make this little contribution to inform of the typos and if you merge the changes I have made to them.

Kind regards,
Waheed